### PR TITLE
Fix Base64 decoder handling of incomplete groups

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -1,3 +1,5 @@
+declare const control: { fail: (msg: string) => void };
+
 namespace u8x3 {
     // our "alphabet" stays the same
     const _c = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
@@ -46,17 +48,13 @@ namespace u8x3 {
         dat = clean
         let out2 = ""
         let j = 0
-        while (j < dat.length) {
+        // Process input in groups of 4 valid Base64 characters
+        while (j + 3 < dat.length) {
             // Get the next 4 characters
             const c12 = dat.charAt(j++)
             const c22 = dat.charAt(j++)
             const c32 = dat.charAt(j++)
             const c4 = dat.charAt(j++)
-
-            // If we don't have 4 characters, break
-            if (c12 === undefined || c22 === undefined || c32 === undefined || c4 === undefined) {
-                break
-            }
 
             // Get indices for the first two characters (must be valid)
             const x12 = _c.indexOf(c12)


### PR DESCRIPTION
## Summary
- avoid processing incomplete Base64 quartets when decoding
- declare missing `control` global to compile outside MakeCode environment

## Testing
- `npx tsc`
- `node -e "const fs=require('fs'); const vm=require('vm'); vm.runInThisContext(fs.readFileSync('built/main.js','utf8')); const valid=u8x3.d2(u8x3.e1('abc')); const incomplete=u8x3.d2('YWJ'); console.log('valid', valid); console.log('incomplete', incomplete.length);"`


------
https://chatgpt.com/codex/tasks/task_e_689785710d088330bccec65d6b9dedcc